### PR TITLE
サーチバーにプレースホルダーを設定

### DIFF
--- a/Qiita Viewer/View/ArticleListViewController.swift
+++ b/Qiita Viewer/View/ArticleListViewController.swift
@@ -23,6 +23,8 @@ class ArticleListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        searchBar.placeholder = "ユーザー名で検索"
+        
         // サーチバーに入力された文字をviewModelにバインディング
         searchBar.rx.text.orEmpty
             .bind(to: self.viewModel.searchWord)


### PR DESCRIPTION
# 内容
サーチバーにプレースホルダーを設定しユーザー名で検索可能であることをわかりやすくしました。