### PR TITLE
ユーザーID検索導入画面を追加

### DIFF
--- a/Qiita Viewer.xcodeproj/project.pbxproj
+++ b/Qiita Viewer.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		842AAE4724F410F1003173D6 /* Article+ComputedProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842AAE4624F410F1003173D6 /* Article+ComputedProperty.swift */; };
 		844899D424F4CFB100994B57 /* UIImage+ConvertionStringToURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844899D324F4CFB100994B57 /* UIImage+ConvertionStringToURL.swift */; };
 		844899D924F61B4E00994B57 /* PKHUD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 844899D824F61B4E00994B57 /* PKHUD.framework */; };
+		84D849FE24F812BF00B6D855 /* StartSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D849FD24F812BF00B6D855 /* StartSearchViewController.swift */; };
 		84FC013D24F0E002001763D4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FC013C24F0E002001763D4 /* AppDelegate.swift */; };
 		84FC013F24F0E002001763D4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FC013E24F0E002001763D4 /* SceneDelegate.swift */; };
 		84FC014624F0E003001763D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84FC014524F0E003001763D4 /* Assets.xcassets */; };
@@ -29,7 +30,7 @@
 		84FC019D24F11350001763D4 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84FC017E24F0F24B001763D4 /* RxRelay.framework */; };
 		84FC019E24F11350001763D4 /* RxRelay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 84FC017E24F0F24B001763D4 /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		84FC01A224F1759E001763D4 /* ArticleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FC01A124F1759E001763D4 /* ArticleListViewController.swift */; };
-		84FC01A424F1765C001763D4 /* ArticleList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84FC01A324F1765C001763D4 /* ArticleList.storyboard */; };
+		84FC01A424F1765C001763D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84FC01A324F1765C001763D4 /* Main.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,7 @@
 		842AAE4624F410F1003173D6 /* Article+ComputedProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Article+ComputedProperty.swift"; sourceTree = "<group>"; };
 		844899D324F4CFB100994B57 /* UIImage+ConvertionStringToURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+ConvertionStringToURL.swift"; sourceTree = "<group>"; };
 		844899D824F61B4E00994B57 /* PKHUD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PKHUD.framework; path = Carthage/Build/iOS/PKHUD.framework; sourceTree = "<group>"; };
+		84D849FD24F812BF00B6D855 /* StartSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartSearchViewController.swift; sourceTree = "<group>"; };
 		84FC013924F0E002001763D4 /* Qiita Viewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Qiita Viewer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		84FC013C24F0E002001763D4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		84FC013E24F0E002001763D4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -92,7 +94,7 @@
 		84FC019824F0F82F001763D4 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		84FC019B24F110C5001763D4 /* ArticleListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListViewModel.swift; sourceTree = "<group>"; };
 		84FC01A124F1759E001763D4 /* ArticleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleListViewController.swift; sourceTree = "<group>"; };
-		84FC01A324F1765C001763D4 /* ArticleList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ArticleList.storyboard; sourceTree = "<group>"; };
+		84FC01A324F1765C001763D4 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -235,8 +237,9 @@
 			isa = PBXGroup;
 			children = (
 				84FC01A124F1759E001763D4 /* ArticleListViewController.swift */,
+				84D849FD24F812BF00B6D855 /* StartSearchViewController.swift */,
 				842AAE4224F3E692003173D6 /* CustomCell.swift */,
-				84FC01A324F1765C001763D4 /* ArticleList.storyboard */,
+				84FC01A324F1765C001763D4 /* Main.storyboard */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -348,7 +351,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				84FC014924F0E003001763D4 /* LaunchScreen.storyboard in Resources */,
-				84FC01A424F1765C001763D4 /* ArticleList.storyboard in Resources */,
+				84FC01A424F1765C001763D4 /* Main.storyboard in Resources */,
 				84FC014624F0E003001763D4 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -408,6 +411,7 @@
 				84FC013D24F0E002001763D4 /* AppDelegate.swift in Sources */,
 				84FC01A224F1759E001763D4 /* ArticleListViewController.swift in Sources */,
 				84FC013F24F0E002001763D4 /* SceneDelegate.swift in Sources */,
+				84D849FE24F812BF00B6D855 /* StartSearchViewController.swift in Sources */,
 				842AAE4724F410F1003173D6 /* Article+ComputedProperty.swift in Sources */,
 				84FC019924F0F82F001763D4 /* User.swift in Sources */,
 			);

--- a/Qiita Viewer/Info.plist
+++ b/Qiita Viewer/Info.plist
@@ -34,7 +34,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>ArticleList</string>
+					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
@@ -42,7 +42,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
-	<string>ArticleList</string>
+	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Qiita Viewer/View/ArticleListViewController.swift
+++ b/Qiita Viewer/View/ArticleListViewController.swift
@@ -19,11 +19,13 @@ class ArticleListViewController: UIViewController {
     
     let viewModel = ArticleListViewModel()
     let disposeBag = DisposeBag()
+    var userName: String?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         searchBar.placeholder = "ユーザー名で検索"
+        searchBar.text = userName
         
         // サーチバーに入力された文字をviewModelにバインディング
         searchBar.rx.text.orEmpty

--- a/Qiita Viewer/View/Main.storyboard
+++ b/Qiita Viewer/View/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vYZ-eQ-r6j">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="h7h-cx-TLH">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -10,7 +10,7 @@
         <!--Article List View Controller-->
         <scene sceneID="SC3-gc-iSY">
             <objects>
-                <viewController id="vYZ-eQ-r6j" customClass="ArticleListViewController" customModule="Qiita_Viewer" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="articleList" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vYZ-eQ-r6j" customClass="ArticleListViewController" customModule="Qiita_Viewer" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="pqu-iE-qy4">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -111,6 +111,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="EqL-dh-3aC"/>
                     </view>
+                    <navigationItem key="navigationItem" id="Tbp-WX-O9Q"/>
                     <connections>
                         <outlet property="searchBar" destination="wtE-Ce-K3e" id="e03-D7-Ujq"/>
                         <outlet property="tableView" destination="Bfr-xw-j8w" id="srZ-ng-XsC"/>
@@ -119,6 +120,52 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dWT-Ff-3Kj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="128.98550724637681" y="77.678571428571431"/>
+        </scene>
+        <!--Start Search View Controller-->
+        <scene sceneID="cmJ-wT-wOh">
+            <objects>
+                <viewController id="h7h-cx-TLH" customClass="StartSearchViewController" customModule="Qiita_Viewer" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XLl-Br-p86">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L0R-XQ-PZ9">
+                                <rect key="frame" x="82" y="383.5" width="250" height="39.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="250" id="GEM-QW-t9H"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lfj-LU-cGa">
+                                <rect key="frame" x="82" y="433" width="250" height="30"/>
+                                <state key="normal" title="Search">
+                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" weight="regular"/>
+                                </state>
+                                <connections>
+                                    <action selector="didTapButton:" destination="h7h-cx-TLH" eventType="touchUpInside" id="1ok-kY-jJw"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="Lfj-LU-cGa" firstAttribute="top" secondItem="L0R-XQ-PZ9" secondAttribute="bottom" constant="10" id="1rC-pH-AIL"/>
+                            <constraint firstItem="Lfj-LU-cGa" firstAttribute="centerY" secondItem="XLl-Br-p86" secondAttribute="centerY" id="c0u-W9-7mV"/>
+                            <constraint firstItem="Lfj-LU-cGa" firstAttribute="centerX" secondItem="XLl-Br-p86" secondAttribute="centerX" id="mEV-BN-2kF"/>
+                            <constraint firstItem="L0R-XQ-PZ9" firstAttribute="centerX" secondItem="XLl-Br-p86" secondAttribute="centerX" id="o05-ZU-SHK"/>
+                            <constraint firstItem="L0R-XQ-PZ9" firstAttribute="leading" secondItem="Lfj-LU-cGa" secondAttribute="leading" id="pl2-7P-uc1"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="bfd-0g-6Ik"/>
+                    </view>
+                    <connections>
+                        <outlet property="searchButton" destination="Lfj-LU-cGa" id="oxR-1n-hwP"/>
+                        <outlet property="textField" destination="L0R-XQ-PZ9" id="uzN-Fj-WSl"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Xk8-Ob-bZU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-884" y="78"/>
         </scene>
     </scenes>
     <resources>

--- a/Qiita Viewer/View/StartSearchViewController.swift
+++ b/Qiita Viewer/View/StartSearchViewController.swift
@@ -1,0 +1,35 @@
+//
+//  StartSearchViewController.swift
+//  Qiita Viewer
+//
+//  Created by Katsuhiro Yamauchi on 2020/08/28.
+//  Copyright © 2020 Katsuhiro Yamauchi. All rights reserved.
+//
+
+import UIKit
+
+class StartSearchViewController: UIViewController {
+    
+    @IBOutlet var searchButton: UIButton!
+    @IBOutlet var textField: UITextField!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        textField.placeholder = "ユーザー名を入力"
+        
+        searchButton.layer.cornerRadius = 5
+        searchButton.layer.borderColor = UIColor.gray.cgColor
+        searchButton.layer.borderWidth = 1
+    }
+    
+
+    @IBAction func didTapButton(_ sender: UIButton) {
+        let storyboard = self.storyboard!
+        let next = storyboard.instantiateViewController(withIdentifier: "articleList") as! ArticleListViewController
+        next.modalPresentationStyle = .fullScreen
+        next.userName = textField.text ?? ""
+
+        self.present(next, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
# 内容
アプリ起動後にユーザーIDを入力し検索を開始するための画面を追加しました。
ユーザーIDを入力しSearchボタンをタップすると記事一覧画面に遷移します。
空欄のままタップした場合は、新着記事が表示されます。