### PR TITLE
ユーザー検索にバリデーションをかける

### DIFF
--- a/Qiita Viewer.xcodeproj/project.pbxproj
+++ b/Qiita Viewer.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		84E3279124F92F530083B08B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84E3278F24F92F530083B08B /* Nimble.framework */; };
 		84E3279224F92F530083B08B /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84E3279024F92F530083B08B /* Quick.framework */; };
 		84F1EFBE25013CF300877117 /* AlamofireImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84F1EFBD25013CF300877117 /* AlamofireImage.framework */; };
+		84F1EFC22502124A00877117 /* UIViewController+hideKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F1EFC12502124A00877117 /* UIViewController+hideKeyboard.swift */; };
+		84F1EFC425024C7C00877117 /* StartSearchViewController+TextFieldInputValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F1EFC325024C7C00877117 /* StartSearchViewController+TextFieldInputValidation.swift */; };
+		84F1EFC62502557C00877117 /* ArticleListViewController+UISearchBarInputValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F1EFC52502557C00877117 /* ArticleListViewController+UISearchBarInputValidation.swift */; };
 		84FC013D24F0E002001763D4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FC013C24F0E002001763D4 /* AppDelegate.swift */; };
 		84FC013F24F0E002001763D4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FC013E24F0E002001763D4 /* SceneDelegate.swift */; };
 		84FC014624F0E003001763D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84FC014524F0E003001763D4 /* Assets.xcassets */; };
@@ -76,6 +79,9 @@
 		84E3278F24F92F530083B08B /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		84E3279024F92F530083B08B /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		84F1EFBD25013CF300877117 /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
+		84F1EFC12502124A00877117 /* UIViewController+hideKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+hideKeyboard.swift"; sourceTree = "<group>"; };
+		84F1EFC325024C7C00877117 /* StartSearchViewController+TextFieldInputValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartSearchViewController+TextFieldInputValidation.swift"; sourceTree = "<group>"; };
+		84F1EFC52502557C00877117 /* ArticleListViewController+UISearchBarInputValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArticleListViewController+UISearchBarInputValidation.swift"; sourceTree = "<group>"; };
 		84FC013924F0E002001763D4 /* Qiita Viewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Qiita Viewer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		84FC013C24F0E002001763D4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		84FC013E24F0E002001763D4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -172,6 +178,9 @@
 			isa = PBXGroup;
 			children = (
 				842AAE4624F410F1003173D6 /* Article+ComputedProperty.swift */,
+				84F1EFC12502124A00877117 /* UIViewController+hideKeyboard.swift */,
+				84F1EFC52502557C00877117 /* ArticleListViewController+UISearchBarInputValidation.swift */,
+				84F1EFC325024C7C00877117 /* StartSearchViewController+TextFieldInputValidation.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -564,6 +573,9 @@
 				84189C892500C7F8003F1FE7 /* LoadingStatus.swift in Sources */,
 				84FC019224F0F553001763D4 /* QiitaApiClient.swift in Sources */,
 				842AAE4324F3E692003173D6 /* CustomCell.swift in Sources */,
+				84F1EFC425024C7C00877117 /* StartSearchViewController+TextFieldInputValidation.swift in Sources */,
+				84F1EFC22502124A00877117 /* UIViewController+hideKeyboard.swift in Sources */,
+				84F1EFC62502557C00877117 /* ArticleListViewController+UISearchBarInputValidation.swift in Sources */,
 				84FC019724F0F7F6001763D4 /* Article.swift in Sources */,
 				84FC013D24F0E002001763D4 /* AppDelegate.swift in Sources */,
 				84FC01A224F1759E001763D4 /* ArticleListViewController.swift in Sources */,

--- a/Qiita Viewer.xcworkspace/xcuserdata/katsuhiro.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Qiita Viewer.xcworkspace/xcuserdata/katsuhiro.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "3990A669-12F2-471C-943D-CCC2027BDA73"
+   type = "0"
+   version = "2.0">
+</Bucket>

--- a/Qiita Viewer/Extension/ArticleListViewController+UISearchBarInputValidation.swift
+++ b/Qiita Viewer/Extension/ArticleListViewController+UISearchBarInputValidation.swift
@@ -1,0 +1,18 @@
+//
+//  ArticleListViewController+UISearchBarInputValidation.swift
+//  Qiita Viewer
+//
+//  Created by Katsuhiro Yamauchi on 2020/09/04.
+//  Copyright © 2020 Katsuhiro Yamauchi. All rights reserved.
+//
+
+import UIKit
+
+extension ArticleListViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let blockStrList = ["~", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "+", "=", "{", "[", "}", "]", "|", "\\", ":", ";", "\"", "\'", "<", ">", ",", ".", "?", "/", "¥", "€", "£", " "]
+        
+        if blockStrList.contains(text) { return false }
+        return true
+    }
+}

--- a/Qiita Viewer/Extension/StartSearchViewController+TextFieldInputValidation.swift
+++ b/Qiita Viewer/Extension/StartSearchViewController+TextFieldInputValidation.swift
@@ -1,0 +1,18 @@
+//
+//  StartSearchViewController+TextFieldInputValidation.swift
+//  Qiita Viewer
+//
+//  Created by Katsuhiro Yamauchi on 2020/09/04.
+//  Copyright © 2020 Katsuhiro Yamauchi. All rights reserved.
+//
+
+import UIKit
+
+extension StartSearchViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString text: String) -> Bool {
+        let blockStrList = ["~", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "+", "=", "{", "[", "}", "]", "|", "\\", ":", ";", "\"", "\'", "<", ">", ",", ".", "?", "/", "¥", "€", "£", " "]
+        
+        if blockStrList.contains(text) { return false }
+        return true
+    }
+}

--- a/Qiita Viewer/Extension/UIViewController+hideKeyboard.swift
+++ b/Qiita Viewer/Extension/UIViewController+hideKeyboard.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController+hideKeyboard.swift
+//  Qiita Viewer
+//
+//  Created by Katsuhiro Yamauchi on 2020/09/04.
+//  Copyright © 2020 Katsuhiro Yamauchi. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    func hideKeyboardWhenTappedAround() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.hideKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc func hideKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/Qiita Viewer/View/ArticleListViewController.swift
+++ b/Qiita Viewer/View/ArticleListViewController.swift
@@ -27,6 +27,7 @@ final class ArticleListViewController: UIViewController {
 
         searchBar.placeholder = "ユーザー名で検索"
         searchBar.text = userName
+        searchBar.delegate = self
 
         // サーチバーに入力された文字をviewModelにバインディング
         searchBar.rx.text.orEmpty

--- a/Qiita Viewer/View/Main.storyboard
+++ b/Qiita Viewer/View/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="h7h-cx-TLH">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="h7h-cx-TLH">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -17,7 +17,7 @@
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="wtE-Ce-K3e">
                                 <rect key="frame" x="0.0" y="44" width="414" height="56"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" spellCheckingType="no" keyboardType="alphabet"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Bfr-xw-j8w">
                                 <rect key="frame" x="0.0" y="100" width="414" height="762"/>
@@ -62,6 +62,7 @@
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.crop.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-CX-7bn" userLabel="Icon Image View">
                                                     <rect key="frame" x="3" y="9" width="60" height="57.5"/>
+                                                    <color key="tintColor" systemColor="systemGray2Color" red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="60" id="bbv-Pq-VUw"/>
                                                         <constraint firstAttribute="height" constant="60" id="dXd-oF-PHr"/>
@@ -135,7 +136,7 @@
                                     <constraint firstAttribute="width" constant="250" id="GEM-QW-t9H"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" spellCheckingType="no" keyboardType="alphabet"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lfj-LU-cGa">
                                 <rect key="frame" x="82" y="433" width="250" height="30"/>

--- a/Qiita Viewer/View/StartSearchViewController.swift
+++ b/Qiita Viewer/View/StartSearchViewController.swift
@@ -17,10 +17,13 @@ final class StartSearchViewController: UIViewController {
         super.viewDidLoad()
 
         textField.placeholder = "ユーザー名を入力"
+        textField.delegate = self
 
         searchButton.layer.cornerRadius = 5
         searchButton.layer.borderColor = UIColor.gray.cgColor
         searchButton.layer.borderWidth = 1
+        
+        hideKeyboardWhenTappedAround() // キーボード外タップでキーボードを隠す
     }
 
     @IBAction func didTapButton(_ sender: UIButton) {


### PR DESCRIPTION
# 概要
検索キーワードに英数字、アンダーバー（ _ ）、ハイフン( - )のみ入力可能とする。
入力された場合された場合検索を実行しない。
もしくは、入力自体を禁止する。